### PR TITLE
Fixed the "The invoked member is not supported in a dynamic assembly." exception.

### DIFF
--- a/src/Ideastrike.Nancy/Models/IdeastrikeContext.cs
+++ b/src/Ideastrike.Nancy/Models/IdeastrikeContext.cs
@@ -4,6 +4,11 @@ namespace Ideastrike.Nancy.Models
 {
     public class IdeastrikeContext : DbContext
     {
+        public IdeastrikeContext()
+        {
+            this.Configuration.ProxyCreationEnabled = false;
+        }
+
         public DbSet<Idea> Ideas { get; set; }
         public DbSet<Activity> Activities { get; set; }
         public DbSet<User> Users { get; set; }


### PR DESCRIPTION
This exception was thrown when trying to use an EF entity as a model for a Razor view.

The reason for that exception was that EF does return objects with types of the form `System.Data.Entity.DynamicProxies.NAME_OF_YOUR_CLASS` that are present in a dynamically created assembly. 

Problem is that Razor doesn't seem to see that assembly, and therefore is not happy with the type of our model.
