### PR TITLE
Bug fix for DataContext lifetime

### DIFF
--- a/src/Ideastrike.Nancy/IdeastrikeBootstrapper.cs
+++ b/src/Ideastrike.Nancy/IdeastrikeBootstrapper.cs
@@ -7,7 +7,7 @@ namespace Ideastrike.Nancy
 {
     public class IdeastrikeBootstrapper : AutofacNancyBootstrapper
     {
-        protected override void ConfigureApplicationContainer(Autofac.ILifetimeScope existingContainer)
+        protected override void ConfigureRequestContainer(Autofac.ILifetimeScope existingContainer)
         {
             var builder = new ContainerBuilder();
             builder.RegisterType<IdeastrikeContext>()

--- a/tests/IdeaStrike.Tests/IdeaStrikeSpecBase.cs
+++ b/tests/IdeaStrike.Tests/IdeaStrikeSpecBase.cs
@@ -22,7 +22,7 @@ namespace IdeaStrike.Tests
             CreateMocks();
             ContainerBuilder builder = CreateContainerBuilder();
 
-            var ideaStrikeTestBootstrapper = new IdeaStrikeTestBootStrapper(builder);
+            var ideaStrikeTestBootstrapper = new IdeaStrikeTestBootStrapper(CreateContainerBuilder);
             ideaStrikeTestBootstrapper.Initialise();
             engine = ideaStrikeTestBootstrapper.GetEngine();
         }

--- a/tests/IdeaStrike.Tests/IdeaStrikeTestBootStrapper.cs
+++ b/tests/IdeaStrike.Tests/IdeaStrikeTestBootStrapper.cs
@@ -1,19 +1,20 @@
 using Autofac;
 using Ideastrike.Nancy;
+using System;
 
 namespace IdeaStrike.Tests
 {
     public class IdeaStrikeTestBootStrapper : IdeastrikeBootstrapper
     {
-        private readonly ContainerBuilder builder;
-        public IdeaStrikeTestBootStrapper(ContainerBuilder builder)
+        private readonly Func<ContainerBuilder> builder;
+        public IdeaStrikeTestBootStrapper(Func<ContainerBuilder> builder)
         {
             this.builder = builder;
         }
 
-        protected override void ConfigureApplicationContainer(ILifetimeScope existingContainer)
+        protected override void ConfigureRequestContainer(ILifetimeScope existingContainer)
         {
-            builder.Update(existingContainer.ComponentRegistry);
+            builder().Update(existingContainer.ComponentRegistry);
         }
     }
 }


### PR DESCRIPTION
Previously the DataContext was singleton over the entire lifetime of the application, and shared between requests. This would cause all sorts of trouble in production.

Switched to making it (and the repositories) scoped to the request.

The way the test bootstrapper was dealing with it's mocks had to change slightly as well. Creates new sets for each request, which is probably better anyway.
You could possibly keep it a single set in the testing by overriding the request behaviour in the main bootstrapper, but at that point why bother even subclassing it.
