### PR TITLE
Main navigation link padding changes, image upload margin changes, and image replacement added for Ideastrike branding.

### DIFF
--- a/src/Ideastrike.Nancy/Resources/style.css
+++ b/src/Ideastrike.Nancy/Resources/style.css
@@ -1,8 +1,18 @@
 ﻿#container { width: 880px;margin-left: auto;margin-right: auto;}
-.brand { background: url('/Resources/logo_small.png') no-repeat;width: 115px;height: 57px;}
+.topbar .brand { 
+    background: url('/Resources/logo_small.png') no-repeat;
+    /* LIR @see http://www.kryogenix.org/code/browser/lir/ */
+    height:0;
+    overflow:hidden;
+    padding:57px 0 0;
+    width: 115px;
+}
 .topbar div > ul, .nav { margin: 5px 10px 0 0;}
+.topbar div > ul a, .nav a {
+    padding-top:14px;
+}
 .topbar form { margin-top: 10px; }
-.topbar h3 a, .topbar .brand { padding: 0px;}
+.topbar h3 a { padding: 0px;}
 .topbar .fill{ background-color:#660000;
                background-repeat:repeat-x;
                background-image:-khtml-gradient(linear, left top, left bottom, from(#400000), to(#660000));
@@ -110,3 +120,6 @@ border: 0;
 .activity { margin-right:75px;}
 .loggedin { color: White; }
 .loggedin img {width:15px; height:15px;}
+#fileupload .span11 {
+    margin-left:5px;
+}

--- a/src/Ideastrike.Nancy/Views/Shared/Layout.cshtml
+++ b/src/Ideastrike.Nancy/Views/Shared/Layout.cshtml
@@ -54,7 +54,7 @@
     <div class="topbar" data-dropdown="dropdown">
         <div class="fill">
             <div class="container">
-                <a class="brand" href="/"></a>
+                <a class="brand" href="/"><h1>Ideastrike</h1></a>
                 <ul class="nav">
                     <li><a href="/">Home</a></li>
                     <li><a href="/idea/new">New Idea</a></li>


### PR DESCRIPTION
Nudged the main navigation links down a bit by increasing the padding.
This lines up the bottom of the heading and main nav link text.

Reduced the margin on the image upload form control so it's left edge
lines up with the other form controls.

Changed the padding and the height of the .topbar .brand CSS to use LIR
for image replacement. Added `<h1>` tag to nested inside the .brand `<a>`
and added the word Ideastrike (`<h1>` can be nested inside `<a>` here as
the doctype is HTML5).
