### PR TITLE
Max thumbnail image width setting added.

### DIFF
--- a/src/Ideastrike.Nancy/Migrations/IdeastrikeDbConfiguration.cs
+++ b/src/Ideastrike.Nancy/Migrations/IdeastrikeDbConfiguration.cs
@@ -28,6 +28,11 @@ namespace Ideastrike.Nancy.Migrations
                 context.SaveChanges();
             }
 
+            if (context.Settings.FirstOrDefault<Setting>(s => s.Key == "MaxThumbnailWidth") == null)
+            {
+                context.Settings.AddOrUpdate(s => s.Key, new Setting { Key = "MaxThumbnailWidth", Value = 1000.ToString() });
+            }
+
             context.Claims.AddOrUpdate(s => s.Name, new Claim { Name = "admin"});
             context.Claims.AddOrUpdate(s => s.Name, new Claim { Name = "moderator" });
 #if DEBUG

--- a/src/Ideastrike.Nancy/Models/Repositories/ISettingsRepository.cs
+++ b/src/Ideastrike.Nancy/Models/Repositories/ISettingsRepository.cs
@@ -7,6 +7,7 @@ namespace Ideastrike.Nancy.Models
         string WelcomeMessage { get; set; }
         string HomePage { get; set; }
         string GAnalyticsKey { get; set; }
+        int MaxThumbnailWidth { get; set; }
         string IdeaStatusDefault { get; set; }
         string IdeaStatusChoices { get; set; }
         void Add(string key, string value);

--- a/src/Ideastrike.Nancy/Models/Repositories/SettingsRepository.cs
+++ b/src/Ideastrike.Nancy/Models/Repositories/SettingsRepository.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 
 namespace Ideastrike.Nancy.Models.Repositories
 {
@@ -89,6 +90,22 @@ namespace Ideastrike.Nancy.Models.Repositories
             {
                 Set("GAnalyticsKey", value);
                 _gAnalyticsKey = value;
+            }
+        }
+
+        private int _maxThumbnailWidth;
+        public int MaxThumbnailWidth
+        {
+            get
+            {
+                if (_maxThumbnailWidth == 0)
+                    _maxThumbnailWidth = Convert.ToInt32(Get("MaxThumbnailWidth"));
+                return _maxThumbnailWidth;
+            }
+            set
+            {
+                Set("MaxThumbnailWidth", value.ToString());
+                _maxThumbnailWidth = value;
             }
         }
 

--- a/src/Ideastrike.Nancy/Modules/AdminModule.cs
+++ b/src/Ideastrike.Nancy/Modules/AdminModule.cs
@@ -65,6 +65,7 @@ namespace Ideastrike.Nancy.Modules
                 m.WelcomeMessage = settings.WelcomeMessage;
                 m.HomePage = settings.HomePage;
                 m.GAnalyticsKey = settings.GAnalyticsKey;
+                m.MaxThumbnailWidth = settings.MaxThumbnailWidth;
 
                 return View["Admin/Settings", m];
             };
@@ -76,6 +77,7 @@ namespace Ideastrike.Nancy.Modules
                 settings.Name = Request.Form.yourname;
                 settings.HomePage = Request.Form.homepage;
                 settings.GAnalyticsKey = Request.Form.analyticskey;
+                settings.MaxThumbnailWidth = Request.Form.maxthumbnailwidth;
                
                 return Response.AsRedirect("/admin/settings");
             };

--- a/src/Ideastrike.Nancy/Modules/IdeaModule.cs
+++ b/src/Ideastrike.Nancy/Modules/IdeaModule.cs
@@ -76,7 +76,12 @@ namespace Ideastrike.Nancy.Modules
                 using (var memoryStream = new MemoryStream(image.ImageBits))
                 {
                     var drawingImage = System.Drawing.Image.FromStream(memoryStream);
-                    var thumb = drawingImage.ToThumbnail((int)parameters.width);
+                    int thumbWidth = (int)parameters.width;
+                    if (thumbWidth > settings.MaxThumbnailWidth)
+                    {
+                        thumbWidth = settings.MaxThumbnailWidth;
+                    }
+                    var thumb = drawingImage.ToThumbnail(thumbWidth);
                     using (var thumbnailStream = new MemoryStream())
                     {
                         // TODO: format should be adaptive based on backing source?

--- a/src/Ideastrike.Nancy/Views/Admin/Settings.cshtml
+++ b/src/Ideastrike.Nancy/Views/Admin/Settings.cshtml
@@ -48,6 +48,18 @@
             <span class="help-block">It should look something like UA-XXXXXXX-X</span>
         </div>
     </div>
+</fieldset>
+<fieldset>
+    <legend>Image Settings</legend>
+    <div class="clearfix">
+        <label for="maxthumbnailwidth">Thumbnail Width</label>
+        <div class="input">
+            <input class="xlarge" id="maxthumbnailwidth" name="maxthumbnailwidth" value="@Model.MaxThumbnailWidth" type="number" />
+            <span class="help-block">The maximum width in pixels for image thumbnails (default is 1000)</span>
+        </div>
+    </div>
+</fieldset>
+<fieldset>
      <div class="input">
         <button type="submit" class="btn primary">Save</button>
      </div>

--- a/tests/IdeaStrike.Tests/AdminModuleTests/when_an_authenticated_user_views_the_settings_page.cs
+++ b/tests/IdeaStrike.Tests/AdminModuleTests/when_an_authenticated_user_views_the_settings_page.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Ideastrike.Nancy.Modules;
+using Xunit;
+using Nancy.Testing;
+
+namespace IdeaStrike.Tests.AdminModuleTests
+{
+    public class when_an_authenticated_user_views_the_settings_page : IdeaStrikeSpecBase<AdminModule>
+    {
+        public when_an_authenticated_user_views_the_settings_page()
+        {
+            EnableFormsAuth();
+
+            Get("/admin/settings", with =>
+            {
+                with.LoggedInUser(CreateMockUser("shiftkey"));
+            }); 
+        }
+
+        public void it_includes_the_max_thumbnail_width_field()
+        {
+            Response.Body["#maxthumbnailwidth"].ShouldExistOnce();
+        }
+    }
+}

--- a/tests/IdeaStrike.Tests/IdeaModuleTests/when_viewing_an_image_thumbnail_with_width_greater_than_max.cs
+++ b/tests/IdeaStrike.Tests/IdeaModuleTests/when_viewing_an_image_thumbnail_with_width_greater_than_max.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Ideastrike.Nancy.Modules;
+using Ideastrike.Nancy.Models;
+using Xunit;
+
+namespace IdeaStrike.Tests.IdeaModuleTests
+{
+    public class when_viewing_an_image_thumbnail_with_width_greater_than_max : IdeaStrikeSpecBase<IdeaModule>
+    {
+        private Image testImage;
+
+        public when_viewing_an_image_thumbnail_with_width_greater_than_max()
+        {
+            testImage = new Image
+            {
+                Id = 1,
+                Name = "Test Image",
+                ImageBits = CreateImageBits(),
+                IdeaId = 1
+            };
+            _Images.Setup(i => i.Get(1)).Returns(testImage);
+            _Settings.SetupGet(s => s.MaxThumbnailWidth).Returns(1000);
+            Get("/idea/imagethumb/1/5000000");
+        }
+
+        [Fact]
+        public void it_should_return_status_ok()
+        {
+            Assert.Equal(Nancy.HttpStatusCode.OK, Response.StatusCode);
+        }
+    }
+}

--- a/tests/IdeaStrike.Tests/IdeaModuleTests/when_viewing_an_image_thumbnail_with_width_less_than_max.cs
+++ b/tests/IdeaStrike.Tests/IdeaModuleTests/when_viewing_an_image_thumbnail_with_width_less_than_max.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Ideastrike.Nancy.Modules;
+using Xunit;
+using Ideastrike.Nancy.Models;
+
+namespace IdeaStrike.Tests.IdeaModuleTests
+{
+    public class when_viewing_an_image_thumbnail_with_width_less_than_max : IdeaStrikeSpecBase<IdeaModule>
+    {
+        private Image testImage;
+
+        public when_viewing_an_image_thumbnail_with_width_less_than_max()
+        {
+            testImage = new Image
+            {
+                Id = 1,
+                Name = "Test Image",
+                ImageBits = CreateImageBits(),
+                IdeaId = 1
+            };
+            _Images.Setup(i => i.Get(1)).Returns(testImage);
+            _Settings.SetupGet(s => s.MaxThumbnailWidth).Returns(1000);
+            Get("/idea/imagethumb/1/500");
+        }
+
+        [Fact]
+        public void it_should_return_status_ok()
+        {
+            Assert.Equal(Nancy.HttpStatusCode.OK, Response.StatusCode);
+        }
+    }
+}

--- a/tests/IdeaStrike.Tests/IdeaStrike.Tests.csproj
+++ b/tests/IdeaStrike.Tests/IdeaStrike.Tests.csproj
@@ -67,6 +67,7 @@
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Core" />
     <Reference Include="System.Data.Entity" />
+    <Reference Include="System.Drawing" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
@@ -79,6 +80,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AdminModuleTests\when_an_authenticated_user_views_the_admin_page.cs" />
+    <Compile Include="AdminModuleTests\when_an_authenticated_user_views_the_settings_page.cs" />
     <Compile Include="AdminModuleTests\when_an_unauthenticated_user_views_the_admin_page.cs" />
     <Compile Include="ApiModuleTests\when_posting_a_new_idea.cs" />
     <Compile Include="ApiModuleTests\when_updating_an_idea.cs" />
@@ -91,6 +93,8 @@
     <Compile Include="IdeaModuleTests\when_an_unauthorized_user_creates_a_new_idea.cs" />
     <Compile Include="IdeaModuleTests\when_creating_a_new_idea.cs" />
     <Compile Include="IdeaModuleTests\when_deleting_a_idea.cs" />
+    <Compile Include="IdeaModuleTests\when_viewing_an_image_thumbnail_with_width_greater_than_max.cs" />
+    <Compile Include="IdeaModuleTests\when_viewing_an_image_thumbnail_with_width_less_than_max.cs" />
     <Compile Include="IdeaModuleTests\when_viewing_the_idea_page.cs" />
     <Compile Include="IdeaModuleTests\when_voting_for_an_item.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/tests/IdeaStrike.Tests/IdeaStrikeSpecBase.cs
+++ b/tests/IdeaStrike.Tests/IdeaStrikeSpecBase.cs
@@ -10,6 +10,9 @@ using Ideastrike.Nancy.Models.Repositories;
 using Moq;
 using Nancy;
 using Nancy.Testing;
+using System.Drawing;
+using System.IO;
+using System.Drawing.Imaging;
 
 namespace IdeaStrike.Tests
 {
@@ -58,6 +61,22 @@ namespace IdeaStrike.Tests
                 RedirectUrl = "~/login",
                 UserMapper = _Users.Object
             });
+        }
+
+        protected byte[] CreateImageBits()
+        {
+            Bitmap img = new Bitmap(10, 10);
+            Graphics imgData = Graphics.FromImage(img);
+            imgData.DrawLine(new Pen(Color.Blue), 0, 0, 10, 10);
+
+            
+            byte[] imageBits = null;
+            using (MemoryStream memoryStream = new MemoryStream())
+            {
+                img.Save(memoryStream, ImageFormat.Bmp);
+                imageBits = memoryStream.ToArray();
+            }
+            return imageBits;
         }
 
         protected void Get(string path, Action<BrowserContext> browserContext = null)


### PR DESCRIPTION
This should fix #74:
- IdeastrikeDbConfiguration's Seed method adds a MaxThumbnailWidth setting if one doesn't exist (I wasn't sure of the best way to add this - the way I've done it relies on you running `update-database` in the package manager console)
- MaxThumbnailWidth property added to ISettingsRepository and SettingsRepository
- AdminModule Get and Post requests to '/admin/settings' save and retrieve the new MaxThumbnailWidth property
- A new field has been added to the form in Settings.cshtml, in a Image Settings `<fieldset>`
- IdeaModule checks the width parameter against `settings.MaxThumbnailWidth` when handling requests to '/imagethumb/{id}/{width}'.
