### PR TITLE
Fix for bug 55. 

### DIFF
--- a/src/Ideastrike.Nancy/Helpers/ModuleExtensions.cs
+++ b/src/Ideastrike.Nancy/Helpers/ModuleExtensions.cs
@@ -102,7 +102,7 @@ namespace Ideastrike
         public static dynamic Model(this NancyContext context, string title)
         {
             dynamic model = new ExpandoObject();
-            model.Title = title;
+            model.Title = string.Format("{0}{1}", (context.CurrentUser != null && context.CurrentUser.Claims.Contains("admin") ? "Admin - " : string.Empty), title).Trim();
             model.IsLoggedIn = context.IsLoggedIn();
             model.UserName = context.Username();
             if (model.IsLoggedIn)

--- a/src/Ideastrike.Nancy/Modules/AdminModule.cs
+++ b/src/Ideastrike.Nancy/Modules/AdminModule.cs
@@ -29,7 +29,7 @@ namespace Ideastrike.Nancy.Modules
 
             Get["/"] = _ =>
             {
-                var m = Context.Model(string.Format("Admin - {0}", settings.Title));
+                var m = Context.Model(settings.Title);
                 m.Name = settings.Name;
                 m.WelcomeMessage = settings.WelcomeMessage;
                 m.HomePage = settings.HomePage;
@@ -39,7 +39,7 @@ namespace Ideastrike.Nancy.Modules
 
             Get["/users"] = _ =>
             {
-                var m = Context.Model(string.Format("Admin - {0}", settings.Title));
+                var m = Context.Model(settings.Title);
                 m.Name = settings.Name;
                 m.WelcomeMessage = settings.WelcomeMessage;
                 m.HomePage = settings.HomePage;
@@ -50,7 +50,7 @@ namespace Ideastrike.Nancy.Modules
 
             Get["/moderation"] = _ =>
             {
-                var m = Context.Model(string.Format("Admin - {0}", settings.Title));
+                var m = Context.Model(settings.Title);
                 m.Name = settings.Name;
                 m.WelcomeMessage = settings.WelcomeMessage;
                 m.HomePage = settings.HomePage;
@@ -60,7 +60,7 @@ namespace Ideastrike.Nancy.Modules
 
             Get["/settings"] = _ =>
             {
-                var m = Context.Model(string.Format("Admin - {0}", settings.Title));
+                var m = Context.Model(settings.Title);
                 m.Name = settings.Name;
                 m.WelcomeMessage = settings.WelcomeMessage;
                 m.HomePage = settings.HomePage;


### PR DESCRIPTION
The initial commit for Bug 55 does not allow the auto prefixing of Admin to title.  This commit retains auto adding of Admin to title BUT only when claim is admin and prevents prefixing the title with Admin multiple times.

Thanks,
Sean
